### PR TITLE
changing the model config

### DIFF
--- a/models/intermediate/finance/int_net_revenues.sql
+++ b/models/intermediate/finance/int_net_revenues.sql
@@ -1,6 +1,6 @@
 {{
   config(
-    materialized='view',
+    materialized='table',
     unique_key=['customer_id', 'transaction_date', 'transaction_currency']
   )
 }}


### PR DESCRIPTION
## Summary
Changed the materialization type from 'view' to 'table' in the customer revenue model to fix configuration compatibility issues.

## Changes Made
- Updated `materialized='view'` to `materialized='table'` in model configuration
- This resolves the incompatibility between view materialization and the `unique_key` configuration
- Enables proper incremental logic functionality that requires table materialization

## Why This Change
- Views don't support `unique_key` configuration in dbt
- The existing incremental logic (`is_incremental()` macro) requires table materialization to function
- This change aligns the model configuration with its intended functionality

## Testing
- [ ] Model builds successfully with new configuration
- [ ] Incremental logic works as expected
- [ ] CI tests pass with table materialization

## Type of Change
- [x] Bug fix (fixes configuration incompatibility)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update